### PR TITLE
[Fix] Eval should not fix both epsilon and seed

### DIFF
--- a/tabular_marl/train_iql.py
+++ b/tabular_marl/train_iql.py
@@ -20,7 +20,7 @@ CONFIG = {
 }
 
 
-def iql_eval(env, config, q_tables, eval_episodes=500, output=True):
+def iql_eval(env, epsilon, q_tables, eval_episodes=500, output=True):
     """
     Evaluate configuration of independent Q-learning on given environment when initialised with given Q-table
 
@@ -34,9 +34,9 @@ def iql_eval(env, config, q_tables, eval_episodes=500, output=True):
     eval_agents = IQL(
             num_agents=env.n_agents,
             action_spaces=env.action_space,
-            gamma=config["gamma"],
-            learning_rate=config["lr"],
-            epsilon=0.0,
+            gamma=0.0,
+            learning_rate=0.0,
+            epsilon=epsilon,
         )
     eval_agents.q_tables = q_tables
 
@@ -105,7 +105,7 @@ def train(env, config, output=True):
 
         if eps_num > 0 and eps_num % config["eval_freq"] == 0:
             mean_return, std_return = iql_eval(
-                env, config, agents.q_tables, output=output
+                env, agents.epsilon, agents.q_tables, output=output
             )
             evaluation_return_means.append(mean_return)
             evaluation_return_stds.append(std_return)


### PR DESCRIPTION
## Issue

I think the eval is broken.

If we set `epsilon=0` then we have deterministic agents and `eval_episodes` becomes useless as `std=0` in any case.

## Fix

Either:
- Use the current `epsilon` to evaluate the agents policy variations (what this PR do)
- Use different seeds and rethink the eval as evaluating the whole training dynamics over different seeds (with `eval_episodes=1`)